### PR TITLE
Explicitly some instance variables via PsychHandler#initialize

### DIFF
--- a/lib/safe_yaml/psych_handler.rb
+++ b/lib/safe_yaml/psych_handler.rb
@@ -5,6 +5,8 @@ module SafeYAML
     def initialize
       @anchors = {}
       @stack = []
+      @current_key = nil
+      @result = nil
     end
 
     def result


### PR DESCRIPTION
It removes below ruby's warning.
- instance variable @{ivar} not initialized
