### PR TITLE
Account for Ruby's multi-line regular expressions

### DIFF
--- a/lib/safe_yaml/transform/to_date.rb
+++ b/lib/safe_yaml/transform/to_date.rb
@@ -1,7 +1,7 @@
 module SafeYAML
   class Transform
     class ToDate
-      MATCHER = /^\d{4}\-\d{2}\-\d{2}$/.freeze
+      MATCHER = /\A\d{4}\-\d{2}\-\d{2}\Z/.freeze
 
       def transform?(value)
         return false unless MATCHER.match(value)

--- a/lib/safe_yaml/transform/to_float.rb
+++ b/lib/safe_yaml/transform/to_float.rb
@@ -1,7 +1,7 @@
 module SafeYAML
   class Transform
     class ToFloat
-      MATCHER = /^(?:\d+(?:\.\d*)?$)|(?:^\.\d+$)/.freeze
+      MATCHER = /\A(?:\d+(?:\.\d*)?\Z)|(?:^\.\d+\Z)/.freeze
 
       def transform?(value)
         return false unless MATCHER.match(value)

--- a/lib/safe_yaml/transform/to_integer.rb
+++ b/lib/safe_yaml/transform/to_integer.rb
@@ -1,7 +1,7 @@
 module SafeYAML
   class Transform
     class ToInteger
-      MATCHER = /^\d+$/.freeze
+      MATCHER = /\A\d+\Z/.freeze
 
       def transform?(value)
         return false unless MATCHER.match(value)

--- a/lib/safe_yaml/transform/to_symbol.rb
+++ b/lib/safe_yaml/transform/to_symbol.rb
@@ -1,7 +1,7 @@
 module SafeYAML
   class Transform
     class ToSymbol
-      MATCHER = /^:\w+$/.freeze
+      MATCHER = /\A:\w+\Z/.freeze
 
       def transform?(value)
         return false unless SafeYAML::OPTIONS[:enable_symbol_parsing] && MATCHER.match(value)

--- a/lib/safe_yaml/transform/to_time.rb
+++ b/lib/safe_yaml/transform/to_time.rb
@@ -3,7 +3,7 @@ module SafeYAML
     class ToTime
       # There isn't a missing '$' there; YAML itself seems to ignore everything at the end of a
       # string that otherwise resembles a time.
-      MATCHER = /^\d{4}\-\d{2}\-\d{2} \d{2}:\d{2}:\d{2}(?:\.\d{1,5})?/.freeze
+      MATCHER = /\A\d{4}\-\d{2}\-\d{2} \d{2}:\d{2}:\d{2}(?:\.\d{1,5})?/.freeze
 
       def transform?(value)
         return false unless MATCHER.match(value)

--- a/spec/transform/to_date_spec.rb
+++ b/spec/transform/to_date_spec.rb
@@ -1,0 +1,19 @@
+require File.join(File.dirname(__FILE__), "..", "spec_helper")
+
+describe SafeYAML::Transform::ToDate do
+  it "returns true when the value matches a valid Date" do
+    subject.transform?("2013-01-01")[0].should == true
+  end
+
+  it "returns false when the value does not match a valid Date" do
+    subject.transform?("foobar").should be_false
+  end
+
+  it "returns false when the value does not end with a Date" do
+    subject.transform?("2013-01-01\nNOT A DATE").should be_false
+  end
+
+  it "returns false when the value does not begin with a Date" do
+    subject.transform?("NOT A DATE\n2013-01-01").should be_false
+  end
+end

--- a/spec/transform/to_float_spec.rb
+++ b/spec/transform/to_float_spec.rb
@@ -1,0 +1,15 @@
+require File.join(File.dirname(__FILE__), "..", "spec_helper")
+
+describe SafeYAML::Transform::ToFloat do
+  it "returns true when the value matches a valid Float" do
+    subject.transform?("20.00").should be_true
+  end
+
+  it "returns false when the value does not match a valid Float" do
+    subject.transform?("foobar").should be_false
+  end
+
+  it "returns false when the value spans multiple lines" do
+    subject.transform?("20.00\nNOT A FLOAT").should be_false
+  end
+end

--- a/spec/transform/to_integer_spec.rb
+++ b/spec/transform/to_integer_spec.rb
@@ -1,0 +1,15 @@
+require File.join(File.dirname(__FILE__), "..", "spec_helper")
+
+describe SafeYAML::Transform::ToInteger do
+  it "returns true when the value matches a valid Integer" do
+    subject.transform?("10")[0].should be_true
+  end
+
+  it "returns false when the value does not match a valid Integer" do
+    subject.transform?("foobar").should be_false
+  end
+
+  it "returns false when the value spans multiple lines" do
+    subject.transform?("10\nNOT AN INTEGER").should be_false
+  end
+end

--- a/spec/transform/to_symbol_spec.rb
+++ b/spec/transform/to_symbol_spec.rb
@@ -1,0 +1,45 @@
+require File.join(File.dirname(__FILE__), "..", "spec_helper")
+
+describe SafeYAML::Transform::ToSymbol do
+  def with_symbol_parsing_value(value)
+    symbol_parsing_flag = YAML.enable_symbol_parsing?
+    SafeYAML::OPTIONS[:enable_symbol_parsing] = value
+
+    yield
+
+  ensure
+    SafeYAML::OPTIONS[:enable_symbol_parsing] = symbol_parsing_flag
+  end
+
+  def with_symbol_parsing(&block)
+    with_symbol_parsing_value(true, &block)
+  end
+
+  def without_symbol_parsing(&block)
+    with_symbol_parsing_value(false, &block)
+  end
+
+  it "returns true when the value matches a valid Symbol" do
+    with_symbol_parsing { subject.transform?(":foo")[0].should be_true }
+  end
+
+  it "returns false when symbol parsing is disabled" do
+    without_symbol_parsing { subject.transform?(":foo").should be_false }
+  end
+
+  it "returns false when the value does not match a valid Symbol" do
+    with_symbol_parsing { subject.transform?("foo").should be_false }
+  end
+
+  it "returns false when the symbol does not begin the line" do
+    with_symbol_parsing do
+      subject.transform?("NOT A SYMBOL\n:foo").should be_false
+    end
+  end
+
+  it "returns false when the symbol does not end the line" do
+    with_symbol_parsing do
+      subject.transform?(":foo\nNOT A SYMBOL").should be_false
+    end
+  end
+end

--- a/spec/transform/to_time_spec.rb
+++ b/spec/transform/to_time_spec.rb
@@ -1,0 +1,15 @@
+require File.join(File.dirname(__FILE__), "..", "spec_helper")
+
+describe SafeYAML::Transform::ToTime do
+  it "returns true when the value matches a valid Time" do
+    subject.transform?("2013-01-01 10:00:00")[0].should == true
+  end
+
+  it "returns false when the value does not match a valid Time" do
+    subject.transform?("not a time").should be_false
+  end
+
+  it "returns false when the beginning of a line does not match a Time" do
+    subject.transform?("NOT A TIME\n2013-01-01 10:00:00").should be_false
+  end
+end


### PR DESCRIPTION
- Ruby uses multi-line regular expressions by default
- Change Transform classes to match beginning and end of String
- Add tests for Transform classes
- More details: http://guides.rubyonrails.org/security.html#regular-expressions
