### PR TITLE
Add option to suppress the log warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Observe:
     > "foo; end; puts %(I'm in yr system!); def bar": "baz"
     > EOYAML
     => "--- !ruby/hash:ExploitableClassBuilder\n\"foo; end; puts %(I'm in yr system!); def bar\": \"baz\"\n"
-    
+
     > YAML.load(yaml)
     I'm in yr system!
     => #<ExploitableClassBuilder:0x007fdbbe2e25d8 @class=#<Class:0x007fdbbe2e2510>>
@@ -80,6 +80,8 @@ By default, when you require the safe_yaml gem in your project, `YAML.load` is p
     YAML.load(yaml, :safe => false) # calls unsafe_load
 
 The default behavior can be switched to unsafe loading by calling `YAML.enable_arbitrary_object_deserialization!`. In this case, the `:safe` flag still has the same effect, but the defaults are reversed (so calling `YAML.load` will have the same behavior as if the safe_yaml gem weren't required).
+
+This gem will also warn you whenever you use `YAML.load` without specifying the `:safe` option. If you do not want to see these messages in your logs, you can say `SafeYAML::OPTIONS[:suppress_warnings] = true` in an initializer.
 
 Notes
 -----

--- a/lib/safe_yaml.rb
+++ b/lib/safe_yaml.rb
@@ -12,7 +12,8 @@ require "safe_yaml/version"
 module SafeYAML
   OPTIONS = {
     :enable_symbol_parsing => false,
-    :enable_arbitrary_object_deserialization => false
+    :enable_arbitrary_object_deserialization => false,
+    :suppress_warnings => false
   }
 end
 
@@ -131,7 +132,7 @@ module YAML
 
     if safe_mode.nil?
       mode = SafeYAML::OPTIONS[:enable_arbitrary_object_deserialization] ? "unsafe" : "safe"
-      Kernel.warn "Called '#{method}' without the :safe option -- defaulting to #{mode} mode."
+      Kernel.warn "Called '#{method}' without the :safe option -- defaulting to #{mode} mode." unless SafeYAML::OPTIONS[:suppress_warnings]
       safe_mode = !SafeYAML::OPTIONS[:enable_arbitrary_object_deserialization]
     end
 

--- a/spec/safe_yaml_spec.rb
+++ b/spec/safe_yaml_spec.rb
@@ -150,6 +150,17 @@ describe YAML do
       end
     }
 
+    context "with :suppress_warnings set to true" do
+      before :each do SafeYAML::OPTIONS[:suppress_warnings] = true; end
+      after :each do SafeYAML::OPTIONS[:suppress_warnings] = false; end
+
+      it "doesn't issue a warning if :suppress_warnings option is set to true" do
+        SafeYAML::OPTIONS[:suppress_warnings] = true
+        Kernel.should_not_receive(:warn)
+        YAML.load(*arguments)
+      end
+    end
+
     it "issues a warning if the :safe option is omitted" do
       silence_warnings do
         Kernel.should_receive(:warn)


### PR DESCRIPTION
The noise generated by the warnings can get annoying, especially since Rails itself is triggering the warnings (on every request!) and I can't do anything about that anyway. 

Thanks for the gem, great idea and much appreciated!
