### PR TITLE
Check arity rather than rely on Ruby version for Psych argument number change

### DIFF
--- a/lib/safe_yaml.rb
+++ b/lib/safe_yaml.rb
@@ -18,11 +18,13 @@ module SafeYAML
 end
 
 module YAML
+  MULTI_ARGUMENT_PSYCH =  RUBY_VERSION >= "1.9.2" && Psych::Parser.instance_method(:parse).arity != 1
+  
   def self.load_with_options(yaml, options={})
     safe_mode = safe_mode_from_options("load", options)
 
     arguments = [yaml]
-    if RUBY_VERSION >= "1.9.2" && Psych::Parser.instance_method(:parse).arity != 1
+    if MULTI_ARGUMENT_PSYCH
       arguments << options[:filename]
     end
 
@@ -84,7 +86,7 @@ module YAML
   class << self
     alias_method :unsafe_load, :load
 
-    if RUBY_VERSION >= "1.9.3"
+    if MULTI_ARGUMENT_PSYCH
       alias_method :load, :load_with_filename_and_options
     else
       alias_method :load, :load_with_options

--- a/spec/safe_yaml_spec.rb
+++ b/spec/safe_yaml_spec.rb
@@ -166,7 +166,7 @@ describe YAML do
 
   describe "load" do
     let (:arguments) {
-      if RUBY_VERSION >= "1.9.3"
+      if YAML::MULTI_ARGUMENT_PSYCH
         ["foo: bar", nil]
       else
         ["foo: bar"]


### PR DESCRIPTION
Fixes Issue #16

Possible interface change:
- safe_load will accept a filename but only pass it on if psych supports receiving it
