### PR TITLE
Handle binary array values

### DIFF
--- a/lib/safe_yaml/transform.rb
+++ b/lib/safe_yaml/transform.rb
@@ -24,15 +24,13 @@ module SafeYAML
 
       value
     end
-    
+
     def self.to_proper_type(value, quoted=false,tag=nil)
       case tag
-      when "tag:yaml.org,2002:binary"
-        return Base64.decode64(value)
-      when "x-private:binary"
-        return Base64.decode64(value)
+      when "tag:yaml.org,2002:binary", "x-private:binary", "!binary"
+        Base64.decode64(value)
       else
-        return self.to_guessed_type(value, quoted)
+        self.to_guessed_type(value, quoted)
       end
     end
   end

--- a/spec/safe_yaml_spec.rb
+++ b/spec/safe_yaml_spec.rb
@@ -127,6 +127,17 @@ describe YAML do
       result.should == {"foo" => "bar", "bar" => "baz"}
     end
 
+    it "works for YAML documents with binary tagged array values" do
+      result = YAML.safe_load <<-YAML
+        - !binary |-
+          Zm9v
+        - !binary |-
+          YmFy
+      YAML
+
+      result.should == ["foo", "bar"]
+    end
+
     it "works for YAML documents with sections" do
       result = YAML.safe_load <<-YAML
         mysql: &mysql


### PR DESCRIPTION
Array values can be tagged with just "!binary" to indicate Base64
encoding. Adds handling for this case.
