### PR TITLE
Fix exception on parsing empty document with syck

### DIFF
--- a/lib/safe_yaml/resolver.rb
+++ b/lib/safe_yaml/resolver.rb
@@ -7,6 +7,10 @@ module SafeYAML
     end
 
     def resolve_node(node)
+      if not node
+        return node
+      end
+      
       case self.get_node_type(node)
       when :root
         resolve_root(node)

--- a/spec/safe_yaml_spec.rb
+++ b/spec/safe_yaml_spec.rb
@@ -239,6 +239,11 @@ describe YAML do
         "grandcustom" => { "foo" => "foo", "bar" => "custom_bar", "baz" => "custom_baz" }
       }
     end
+    
+    it "returns false when parsing an empty document" do
+      result = YAML.safe_load ""
+      result.should == false
+    end
 
     context "with custom initializers defined" do
       before :each do


### PR DESCRIPTION
On parsing an empty YAML document on ree-1.8.7 (syck backend) was getting an exception:

NoMethodError: undefined method `value' for false:FalseClass

Triggered by the method SafeYAML::Resolver#resolve_node being called with "false" as its parameter. This happens where no root node is present.

Have added a check that if this method is called with false or nil it will return its argument unaltered. Result for an empty document seems to be consistent on psych - false in both cases.
