### PR TITLE
Fix "Unknown YAML Tag '!'" error when deserializing custom ruby objects

### DIFF
--- a/lib/safe_yaml/safe_to_ruby_visitor.rb
+++ b/lib/safe_yaml/safe_to_ruby_visitor.rb
@@ -7,7 +7,7 @@ module SafeYAML
 
     def accept(node)
       if node.tag
-        return super if @resolver.tag_is_whitelisted?(node.tag)
+        return super if @resolver.tag_is_whitelisted?(node.tag) || node.tag == "!"
         raise "Unknown YAML tag '#{node.tag}'" if @resolver.options[:raise_on_unknown_tag]
       end
 

--- a/spec/safe_yaml_spec.rb
+++ b/spec/safe_yaml_spec.rb
@@ -390,6 +390,24 @@ describe YAML do
           expect { result = YAML.safe_load "--- ! 'foo'" }.to_not raise_error
           result.should == "foo"
         end
+
+        context "with whitelisted custom class" do
+          class SomeClass
+            attr_accessor :foo
+          end
+          let(:instance) { SomeClass.new }
+
+          before do
+            SafeYAML::whitelist!(SomeClass)
+            instance.foo = 'with trailing whitespace: '
+          end
+
+          it "does not raise an exception on the non-specific '!' tag" do
+            result = nil
+            expect { result = YAML.safe_load(instance.to_yaml) }.to_not raise_error
+            result.foo.should == 'with trailing whitespace: '
+          end
+        end
       end
     end
 


### PR DESCRIPTION
Under certain circumstances #34 was still occuring, this reproduces and fixes it.
