### PR TITLE
Correctly parse 0 as a Fixnum

### DIFF
--- a/lib/safe_yaml/transform/to_integer.rb
+++ b/lib/safe_yaml/transform/to_integer.rb
@@ -2,10 +2,10 @@ module SafeYAML
   class Transform
     class ToInteger
       MATCHERS = Deep.freeze([
-        /\A[-+]?[1-9][0-9_,]*\Z/, # decimal
-        /\A0[0-7]+\Z/,            # octal
-        /\A0x[0-9a-f]+\Z/i,       # hexadecimal
-        /\A0b[01_]+\Z/            # binary
+        /\A[-+]?(0|([1-9][0-9_,]*))\Z/, # decimal
+        /\A0[0-7]+\Z/,                  # octal
+        /\A0x[0-9a-f]+\Z/i,             # hexadecimal
+        /\A0b[01_]+\Z/                  # binary
       ])
 
       def transform?(value)

--- a/spec/transform/to_integer_spec.rb
+++ b/spec/transform/to_integer_spec.rb
@@ -29,6 +29,10 @@ describe SafeYAML::Transform::ToInteger do
     subject.transform?("09").should be_false
   end
 
+  it "correctly parses 0 in decimal" do
+    subject.transform?("0").should == [true, 0]
+  end
+
   it "defaults to a string for a number that resembles hexadecimal format but is not" do
     subject.transform?("0x1G").should be_false
   end
@@ -42,7 +46,7 @@ describe SafeYAML::Transform::ToInteger do
 
     # octal
     subject.transform?("02472256").should == [true, 685230]
-    
+
     # hexadecimal:
     subject.transform?("0x_0A_74_AE").should == [true, 685230]
 


### PR DESCRIPTION
I had a bit of an issue when parsing a simple array of integers in that 0 would always return a string:

``` ruby
yaml = [0, 1].to_yaml
YAML.load(yaml)
 => ["0", 1]
```
