### PR TITLE
ToSymbol: Update regexp to match more symbols

### DIFF
--- a/lib/safe_yaml/transform/to_symbol.rb
+++ b/lib/safe_yaml/transform/to_symbol.rb
@@ -1,12 +1,16 @@
 module SafeYAML
   class Transform
     class ToSymbol
-      MATCHER = /\A:"?(\w+)"?\Z/.freeze
+      def transform?(value, options=SafeYAML::OPTIONS)
+        if options[:deserialize_symbols] && value =~ /\A:./
+          if value =~ /\A:(["'])(.*)\1\Z/
+            return true, $2.sub(/^:/, "").to_sym
+          else
+            return true, value.sub(/^:/, "").to_sym
+          end
+        end
 
-      def transform?(value, options=nil)
-        options ||= SafeYAML::OPTIONS
-        return false unless options[:deserialize_symbols] && MATCHER.match(value)
-        return true, $1.to_sym
+        return false
       end
     end
   end

--- a/spec/transform/to_symbol_spec.rb
+++ b/spec/transform/to_symbol_spec.rb
@@ -27,6 +27,14 @@ describe SafeYAML::Transform::ToSymbol do
     with_symbol_deserialization { subject.transform?(':"foo"')[0].should be_true }
   end
 
+  it "returns true when the value matches a valid String+Symbol with 's" do
+    with_symbol_deserialization { subject.transform?(":'foo'")[0].should be_true }
+  end
+
+  it "returns true when the value has special characters and is wrapped in a String" do
+    with_symbol_deserialization { subject.transform?(':"foo.bar"')[0].should be_true }
+  end
+
   it "returns false when symbol deserialization is disabled" do
     without_symbol_deserialization { subject.transform?(":foo").should be_false }
   end
@@ -38,12 +46,6 @@ describe SafeYAML::Transform::ToSymbol do
   it "returns false when the symbol does not begin the line" do
     with_symbol_deserialization do
       subject.transform?("NOT A SYMBOL\n:foo").should be_false
-    end
-  end
-
-  it "returns false when the symbol does not end the line" do
-    with_symbol_deserialization do
-      subject.transform?(":foo\nNOT A SYMBOL").should be_false
     end
   end
 end


### PR DESCRIPTION
The new regexp adds support for matching symbols like:
- `:"foo.bar"`
- `:'foobar'`
- `:foo.bar`
- `:"foo\nbar"`

All of these are compatible with how Psych dumps symbols.
