### PR TITLE
When Syck is not present at all, stub it out and proceed

### DIFF
--- a/lib/safe_yaml/syck_hack.rb
+++ b/lib/safe_yaml/syck_hack.rb
@@ -21,6 +21,8 @@ module YAML
   # JRuby's "Syck" is called "Yecht"
   elsif defined? YAML::Yecht
     Syck = YAML::Yecht
+  elsif !defined? YAML::Syck
+    module Syck; end
   end
 end
 


### PR DESCRIPTION
In some circumstances (at the very least, a clean install of JRuby 1.7.6 running in Ruby 2.0 mode), there is no YAML::Yecht name defined, nor is there a YAML::Syck. This causes safe_yaml to fail to run in those circumstances. Stubbing this namespace out (the same thing rubygems does) seems to resolve it.
