### PR TITLE
[bugfix] Substitute _ for decimal values

### DIFF
--- a/lib/safe_yaml/transform/to_integer.rb
+++ b/lib/safe_yaml/transform/to_integer.rb
@@ -9,7 +9,8 @@ module SafeYAML
       ])
 
       def transform?(value)
-        MATCHERS.each do |matcher|
+        MATCHERS.each_with_index do |matcher, idx|
+          value = value.gsub("_", "") if idx == 0
           return true, Integer(value.gsub(",", "")) if matcher.match(value)
         end
         try_edge_cases?(value)


### PR DESCRIPTION
This fixes a bug with the `ToInteger#transform?` implementation.

Suppose you have a key:value pair of `wordpress_id: 850_`. `Integer(value.gsub(",", ""))` causes an `ArgumentError`, because the `_` is not stripped away.

Right now we're checking if the first matcher--the decimal value--has an `_` and getting rid of it. We can't just parse the `_` away, because binary values (`/\A0b[01_]+\Z`) still need it.
