### PR TITLE
In case of an invalid date, return a string

### DIFF
--- a/lib/safe_yaml/parse/date.rb
+++ b/lib/safe_yaml/parse/date.rb
@@ -29,6 +29,8 @@ module SafeYAML
         usec = d.sec_fraction * SEC_FRACTION_MULTIPLIER
         time = Time.utc(d.year, d.month, d.day, d.hour, d.min, d.sec, usec) - (d.offset * SECONDS_PER_DAY)
         time.getlocal
+      rescue ArgumentError
+        value.to_s
       end
     end
   end


### PR DESCRIPTION
Users! They're incredible and we :heart: them.

In YAML, if you pass in a date like this: `0000-00-00 00:00:00 -0000`

The `safe_yaml` gem barfs with an `ArgumentError: invalid date`.

In such a case, just return the value as a string.
