### PR TITLE
No longer shadow variable "node" warning in resolver.rb

### DIFF
--- a/lib/safe_yaml/resolver.rb
+++ b/lib/safe_yaml/resolver.rb
@@ -52,7 +52,7 @@ module SafeYAML
       tag = get_and_check_node_tag(node)
       arr = @initializers.include?(tag) ? @initializers[tag].call : []
 
-      seq.inject(arr) { |array, node| array << resolve_node(node) }
+      seq.inject(arr) { |array, n| array << resolve_node(n) }
     end
 
     def resolve_scalar(node)


### PR DESCRIPTION
Before this, a warning was printed:

``` bash
> ruby -W2 -e 'require "safe_yaml/resolver"'
./safe_yaml/lib/safe_yaml/resolver.rb:55: warning: shadowing outer local variable - node
```
