### PR TITLE
Convert specs to RSpec 3.0.2 syntax with Transpec

### DIFF
--- a/spec/libyaml_checker_spec.rb
+++ b/spec/libyaml_checker_spec.rb
@@ -8,7 +8,7 @@ describe SafeYAML::LibyamlChecker do
     let(:libyaml_patched) { false }
 
     before :each do
-      SafeYAML::LibyamlChecker.stub(:libyaml_patched?).and_return(libyaml_patched)
+      allow(SafeYAML::LibyamlChecker).to receive(:libyaml_patched?).and_return(libyaml_patched)
     end
 
     after :each do
@@ -22,7 +22,7 @@ describe SafeYAML::LibyamlChecker do
       silence_warnings do
         SafeYAML.const_set("YAML_ENGINE", yaml_engine)
         SafeYAML::LibyamlChecker.const_set("LIBYAML_VERSION", libyaml_version)
-        SafeYAML::LibyamlChecker.libyaml_version_ok?.should == expected_result
+        expect(SafeYAML::LibyamlChecker.libyaml_version_ok?).to eq(expected_result)
       end
     end
 

--- a/spec/resolver_specs.rb
+++ b/spec/resolver_specs.rb
@@ -39,7 +39,7 @@ module ResolverSpecs
           Kernel.warn "#{exception_thrown.inspect}\n"
 
         else
-          safe_result.should == unsafe_result
+          expect(safe_result).to eq(unsafe_result)
         end
       end
 
@@ -50,10 +50,10 @@ module ResolverSpecs
             tomayto: tomahto
           YAML
 
-          result.should == {
+          expect(result).to eq({
             "potayto" => "potahto",
             "tomayto" => "tomahto"
-          }
+          })
         end
 
         it "translates sequences to arrays" do
@@ -63,32 +63,32 @@ module ResolverSpecs
             - baz
           YAML
 
-          result.should == ["foo", "bar", "baz"]
+          expect(result).to eq(["foo", "bar", "baz"])
         end
 
         it "translates most values to strings" do
           parse "string: value"
-          result.should == { "string" => "value" }
+          expect(result).to eq({ "string" => "value" })
         end
 
         it "does not deserialize symbols" do
           parse ":symbol: value"
-          result.should == { ":symbol" => "value" }
+          expect(result).to eq({ ":symbol" => "value" })
         end
 
         it "translates valid integral numbers to integers" do
           parse "integer: 1"
-          result.should == { "integer" => 1 }
+          expect(result).to eq({ "integer" => 1 })
         end
 
         it "translates valid decimal numbers to floats" do
           parse "float: 3.14"
-          result.should == { "float" => 3.14 }
+          expect(result).to eq({ "float" => 3.14 })
         end
 
         it "translates valid dates" do
           parse "date: 2013-01-24"
-          result.should == { "date" => Date.parse("2013-01-24") }
+          expect(result).to eq({ "date" => Date.parse("2013-01-24") })
         end
 
         it "translates valid true/false values to booleans" do
@@ -99,7 +99,7 @@ module ResolverSpecs
             - false
           YAML
 
-          result.should == [true, true, false, false]
+          expect(result).to eq([true, true, false, false])
         end
 
         it "translates valid nulls to nil" do
@@ -109,7 +109,7 @@ module ResolverSpecs
             - null
           YAML
 
-          result.should == [nil] * 3
+          expect(result).to eq([nil] * 3)
         end
 
         it "matches the behavior of the underlying YAML engine w/ respect to capitalization of boolean values" do
@@ -143,12 +143,12 @@ module ResolverSpecs
 
         it "translates quoted empty strings to strings (not nil)" do
           parse "foo: ''"
-          result.should == { "foo" => "" }
+          expect(result).to eq({ "foo" => "" })
         end
 
         it "correctly reverse-translates strings encoded via #to_yaml" do
           parse "5.10".to_yaml
-          result.should == "5.10"
+          expect(result).to eq("5.10")
         end
 
         it "does not specially parse any double-quoted strings" do
@@ -161,7 +161,7 @@ module ResolverSpecs
             - "2013-02-03 16:27:00 -0600"
           YAML
 
-          result.should == ["1", "3.14", "true", "false", "2013-02-03", "2013-02-03 16:27:00 -0600"]
+          expect(result).to eq(["1", "3.14", "true", "false", "2013-02-03", "2013-02-03 16:27:00 -0600"])
         end
 
         it "does not specially parse any single-quoted strings" do
@@ -174,7 +174,7 @@ module ResolverSpecs
             - '2013-02-03 16:27:00 -0600'
           YAML
 
-          result.should == ["1", "3.14", "true", "false", "2013-02-03", "2013-02-03 16:27:00 -0600"]
+          expect(result).to eq(["1", "3.14", "true", "false", "2013-02-03", "2013-02-03 16:27:00 -0600"])
         end
 
         it "deals just fine with nested maps" do
@@ -184,7 +184,7 @@ module ResolverSpecs
                 marco: polo
           YAML
 
-          result.should == { "foo" => { "bar" => { "marco" => "polo" } } }
+          expect(result).to eq({ "foo" => { "bar" => { "marco" => "polo" } } })
         end
 
         it "deals just fine with nested sequences" do
@@ -198,7 +198,7 @@ module ResolverSpecs
                 - baz2
           YAML
 
-          result.should == ["foo", ["bar1", "bar2", ["baz1", "baz2"]]]
+          expect(result).to eq(["foo", ["bar1", "bar2", ["baz1", "baz2"]]])
         end
 
         it "applies the same transformations to keys as to values" do
@@ -210,13 +210,13 @@ module ResolverSpecs
             2013-01-24: date
           YAML
 
-          result.should == {
+          expect(result).to eq({
             "foo"  => "string",
             ":bar" => "symbol",
             1      => "integer",
             3.14   => "float",
             Date.parse("2013-01-24") => "date",
-          }
+          })
         end
 
         it "applies the same transformations to elements in sequences as to all values" do
@@ -228,24 +228,24 @@ module ResolverSpecs
             - 2013-01-24
           YAML
 
-          result.should == ["foo", ":bar", 1, 3.14, Date.parse("2013-01-24")]
+          expect(result).to eq(["foo", ":bar", 1, 3.14, Date.parse("2013-01-24")])
         end
       end
 
       context "for Ruby version #{RUBY_VERSION}" do
         it "translates valid time values" do
           parse "time: 2013-01-29 05:58:00 -0800"
-          result.should == { "time" => Time.utc(2013, 1, 29, 13, 58, 0) }
+          expect(result).to eq({ "time" => Time.utc(2013, 1, 29, 13, 58, 0) })
         end
 
         it "applies the same transformation to elements in sequences" do
           parse "- 2013-01-29 05:58:00 -0800"
-          result.should == [Time.utc(2013, 1, 29, 13, 58, 0)]
+          expect(result).to eq([Time.utc(2013, 1, 29, 13, 58, 0)])
         end
 
         it "applies the same transformation to keys" do
           parse "2013-01-29 05:58:00 -0800: time"
-          result.should == { Time.utc(2013, 1, 29, 13, 58, 0) => "time" }
+          expect(result).to eq({ Time.utc(2013, 1, 29, 13, 58, 0) => "time" })
         end
       end
 
@@ -260,17 +260,17 @@ module ResolverSpecs
 
         it "translates values starting with ':' to symbols" do
           parse "symbol: :value"
-          result.should == { "symbol" => :value }
+          expect(result).to eq({ "symbol" => :value })
         end
 
         it "applies the same transformation to keys" do
           parse ":bar: symbol"
-          result.should == { :bar  => "symbol" }
+          expect(result).to eq({ :bar  => "symbol" })
         end
 
         it "applies the same transformation to elements in sequences" do
           parse "- :bar"
-          result.should == [:bar]
+          expect(result).to eq([:bar])
         end
       end
     end

--- a/spec/safe_yaml_spec.rb
+++ b/spec/safe_yaml_spec.rb
@@ -28,18 +28,18 @@ describe YAML do
     if SafeYAML::YAML_ENGINE == "psych" && RUBY_VERSION >= "1.9.3"
       it "allows exploits through objects defined in YAML w/ !ruby/hash via custom :[]= methods" do
         backdoor = YAML.unsafe_load("--- !ruby/hash:ExploitableBackDoor\nfoo: bar\n")
-        backdoor.should be_exploited_through_setter
+        expect(backdoor).to be_exploited_through_setter
       end
 
       it "allows exploits through objects defined in YAML w/ !ruby/object via the :init_with method" do
         backdoor = YAML.unsafe_load("--- !ruby/object:ExploitableBackDoor\nfoo: bar\n")
-        backdoor.should be_exploited_through_init_with
+        expect(backdoor).to be_exploited_through_init_with
       end
     end
 
     it "allows exploits through objects w/ sensitive instance variables defined in YAML w/ !ruby/object" do
       backdoor = YAML.unsafe_load("--- !ruby/object:ExploitableBackDoor\nfoo: bar\n")
-      backdoor.should be_exploited_through_ivars
+      expect(backdoor).to be_exploited_through_ivars
     end
 
     context "with special whitelisted tags defined" do
@@ -55,8 +55,8 @@ describe YAML do
               foo: bar
         YAML
 
-        result.should be_a(OpenStruct)
-        result.backdoor.should be_exploited_through_ivars
+        expect(result).to be_a(OpenStruct)
+        expect(result.backdoor).to be_exploited_through_ivars
       end
     end
   end
@@ -64,12 +64,12 @@ describe YAML do
   describe "safe_load" do
     it "does NOT allow exploits through objects defined in YAML w/ !ruby/hash" do
       object = YAML.safe_load("--- !ruby/hash:ExploitableBackDoor\nfoo: bar\n")
-      object.should_not be_a(ExploitableBackDoor)
+      expect(object).not_to be_a(ExploitableBackDoor)
     end
 
     it "does NOT allow exploits through objects defined in YAML w/ !ruby/object" do
       object = YAML.safe_load("--- !ruby/object:ExploitableBackDoor\nfoo: bar\n")
-      object.should_not be_a(ExploitableBackDoor)
+      expect(object).not_to be_a(ExploitableBackDoor)
     end
 
     context "for YAML engine #{SafeYAML::YAML_ENGINE}" do
@@ -79,7 +79,7 @@ describe YAML do
 
         context "when no tags are whitelisted" do
           it "constructs a SafeYAML::PsychHandler to resolve nodes as they're parsed, for optimal performance" do
-            Psych::Parser.should_receive(:new).with an_instance_of(SafeYAML::PsychHandler)
+            expect(Psych::Parser).to receive(:new).with an_instance_of(SafeYAML::PsychHandler)
             # This won't work now; we just want to ensure Psych::Parser#parse was in fact called.
             YAML.safe_load(*arguments) rescue nil
           end
@@ -91,7 +91,7 @@ describe YAML do
           }
 
           it "instead uses Psych to construct a full tree before examining the nodes" do
-            Psych.should_receive(:parse)
+            expect(Psych).to receive(:parse)
             # This won't work now; we just want to ensure Psych::Parser#parse was in fact called.
             YAML.safe_load(*arguments) rescue nil
           end
@@ -100,7 +100,7 @@ describe YAML do
 
       if SafeYAML::YAML_ENGINE == "syck"
         it "uses Syck internally to parse YAML" do
-          YAML.should_receive(:parse).with("foo: bar")
+          expect(YAML).to receive(:parse).with("foo: bar")
           # This won't work now; we just want to ensure YAML::parse was in fact called.
           YAML.safe_load("foo: bar") rescue nil
         end
@@ -120,7 +120,7 @@ describe YAML do
             - bye
       YAML
 
-      result.should == {
+      expect(result).to eq({
         "foo" => {
           "number"   => 1,
           "boolean"  => true,
@@ -129,7 +129,7 @@ describe YAML do
           "symbol"   => ":blah",
           "sequence" => ["hi", "bye"]
         }
-      }
+      })
     end
 
     it "works for YAML documents with anchors and aliases" do
@@ -139,7 +139,7 @@ describe YAML do
         - *id001
       YAML
 
-      result.should == [{}, {}, {}]
+      expect(result).to eq([{}, {}, {}])
     end
 
     it "works for YAML documents with binary tagged keys" do
@@ -152,7 +152,7 @@ describe YAML do
         : "baz"
       YAML
 
-      result.should == {"foo" => "bar", "bar" => "baz"}
+      expect(result).to eq({"foo" => "bar", "bar" => "baz"})
     end
 
     it "works for YAML documents with binary tagged values" do
@@ -163,7 +163,7 @@ describe YAML do
           YmF6
       YAML
 
-      result.should == {"foo" => "bar", "bar" => "baz"}
+      expect(result).to eq({"foo" => "bar", "bar" => "baz"})
     end
 
     it "works for YAML documents with binary tagged array values" do
@@ -174,7 +174,7 @@ describe YAML do
           YmFy
       YAML
 
-      result.should == ["foo", "bar"]
+      expect(result).to eq(["foo", "bar"])
     end
 
     it "works for YAML documents with sections" do
@@ -191,7 +191,7 @@ describe YAML do
           host: localhost
       YAML
 
-      result.should == {
+      expect(result).to eq({
         "mysql" => {
           "adapter" => "mysql",
           "pool"    => 30
@@ -207,7 +207,7 @@ describe YAML do
           "password" => "password123",
           "host"     => "localhost"
         }
-      }
+      })
     end
 
     it "correctly prefers explicitly defined values over default values from included sections" do
@@ -225,11 +225,11 @@ describe YAML do
             baz: custom_baz
         YAML
 
-        result["custom"].should == {
+        expect(result["custom"]).to eq({
           "foo" => "foo",
           "bar" => "custom_bar",
           "baz" => "custom_baz"
-        }
+        })
       end
     end
 
@@ -247,26 +247,26 @@ describe YAML do
           <<: *custom
       YAML
 
-      result.should == {
+      expect(result).to eq({
         "defaults"    => { "foo" => "foo", "bar" => "bar", "baz" => "baz" },
         "custom"      => { "foo" => "foo", "bar" => "custom_bar", "baz" => "custom_baz" },
         "grandcustom" => { "foo" => "foo", "bar" => "custom_bar", "baz" => "custom_baz" }
-      }
+      })
     end
 
     it "returns false when parsing an empty document" do
-      [
+      expect([
         YAML.safe_load(""),
         YAML.safe_load("     "),
         YAML.safe_load("\n")
-      ].should == [false, false, false]
+      ]).to eq([false, false, false])
     end
 
     it "returns nil when parsing a single value representing nil" do
-      [
+      expect([
         YAML.safe_load("~"),
         YAML.safe_load("null")
-      ].should == [nil, nil]
+      ]).to eq([nil, nil])
     end
 
     context "with custom initializers defined" do
@@ -292,8 +292,8 @@ describe YAML do
           - 3
         YAML
 
-        result.should be_a(Set)
-        result.to_a.should =~ [1, 2, 3]
+        expect(result).to be_a(Set)
+        expect(result.to_a).to match_array([1, 2, 3])
       end
 
       it "will use a custom initializer to instantiate a hash-like class upon deserialization" do
@@ -302,8 +302,8 @@ describe YAML do
           foo: bar
         YAML
 
-        result.should be_a(Hashie::Mash)
-        result.to_hash.should == { "foo" => "bar" }
+        expect(result).to be_a(Hashie::Mash)
+        expect(result.to_hash).to eq({ "foo" => "bar" })
       end
     end
 
@@ -317,14 +317,14 @@ describe YAML do
 
       it "will allow objects to be deserialized for whitelisted tags" do
         result = YAML.safe_load("--- !ruby/object:OpenStruct\ntable:\n  foo: bar\n")
-        result.should be_a(OpenStruct)
-        result.instance_variable_get(:@table).should == { "foo" => "bar" }
+        expect(result).to be_a(OpenStruct)
+        expect(result.instance_variable_get(:@table)).to eq({ "foo" => "bar" })
       end
 
       it "will not deserialize objects without whitelisted tags" do
         result = YAML.safe_load("--- !ruby/hash:ExploitableBackDoor\nfoo: bar\n")
-        result.should_not be_a(ExploitableBackDoor)
-        result.should == { "foo" => "bar" }
+        expect(result).not_to be_a(ExploitableBackDoor)
+        expect(result).to eq({ "foo" => "bar" })
       end
 
       it "will not allow non-whitelisted objects to be embedded within objects with whitelisted tags" do
@@ -335,9 +335,9 @@ describe YAML do
               foo: bar
         YAML
 
-        result.should be_a(OpenStruct)
-        result.backdoor.should_not be_a(ExploitableBackDoor)
-        result.backdoor.should == { "foo" => "bar" }
+        expect(result).to be_a(OpenStruct)
+        expect(result.backdoor).not_to be_a(ExploitableBackDoor)
+        expect(result.backdoor).to eq({ "foo" => "bar" })
       end
 
       context "with the :raise_on_unknown_tag option enabled" do
@@ -350,23 +350,23 @@ describe YAML do
         end
 
         it "raises an exception if a non-nil, non-whitelisted tag is encountered" do
-          lambda {
+          expect {
             YAML.safe_load <<-YAML.unindent
               --- !ruby/object:Unknown
               foo: bar
             YAML
-          }.should raise_error
+          }.to raise_error
         end
 
         it "checks all tags, even those within objects with trusted tags" do
-          lambda {
+          expect {
             YAML.safe_load <<-YAML.unindent
               --- !ruby/object:OpenStruct
               table:
                 :backdoor: !ruby/object:Unknown
                   foo: bar
             YAML
-          }.should raise_error
+          }.to raise_error
         end
 
         it "does not raise an exception as long as all tags are whitelisted" do
@@ -383,8 +383,8 @@ describe YAML do
                 hash: {}
           YAML
 
-          result.should be_a(OpenStruct)
-          result.backdoor.should == {
+          expect(result).to be_a(OpenStruct)
+          expect(result.backdoor).to eq({
             "string"  => "foo",
             "integer" => 1,
             "float"   => 3.14,
@@ -392,13 +392,13 @@ describe YAML do
             "date"    => Date.parse("2013-02-20"),
             "array"   => [],
             "hash"    => {}
-          }
+          })
         end
 
         it "does not raise an exception on the non-specific '!' tag" do
           result = nil
           expect { result = YAML.safe_load "--- ! 'foo'" }.to_not raise_error
-          result.should == "foo"
+          expect(result).to eq("foo")
         end
 
         context "with whitelisted custom class" do
@@ -415,7 +415,7 @@ describe YAML do
           it "does not raise an exception on the non-specific '!' tag" do
             result = nil
             expect { result = YAML.safe_load(instance.to_yaml) }.to_not raise_error
-            result.foo.should == 'with trailing whitespace: '
+            expect(result.foo).to eq('with trailing whitespace: ')
           end
         end
       end
@@ -433,14 +433,14 @@ describe YAML do
 
         it "goes with the default option when it is not overridden" do
           silence_warnings do
-            YAML.load(":foo: bar").should == { :foo => "bar" }
+            expect(YAML.load(":foo: bar")).to eq({ :foo => "bar" })
           end
         end
 
         it "allows the default option to be overridden on a per-call basis" do
           silence_warnings do
-            YAML.load(":foo: bar", :deserialize_symbols => false).should == { ":foo" => "bar" }
-            YAML.load(":foo: bar", :deserialize_symbols => true).should == { :foo => "bar" }
+            expect(YAML.load(":foo: bar", :deserialize_symbols => false)).to eq({ ":foo" => "bar" })
+            expect(YAML.load(":foo: bar", :deserialize_symbols => true)).to eq({ :foo => "bar" })
           end
         end
       end
@@ -457,16 +457,16 @@ describe YAML do
 
         it "goes with the default option when it is not overridden" do
           result = safe_load_round_trip(OpenStruct.new(:foo => "bar"))
-          result.should be_a(OpenStruct)
-          result.foo.should == "bar"
+          expect(result).to be_a(OpenStruct)
+          expect(result.foo).to eq("bar")
         end
 
         it "allows the default option to be overridden on a per-call basis" do
           result = safe_load_round_trip(OpenStruct.new(:foo => "bar"), :whitelisted_tags => [])
-          result.should == { "table" => { :foo => "bar" } }
+          expect(result).to eq({ "table" => { :foo => "bar" } })
 
           result = safe_load_round_trip(OpenStruct.new(:foo => "bar"), :deserialize_symbols => false, :whitelisted_tags => [])
-          result.should == { "table" => { ":foo" => "bar" } }
+          expect(result).to eq({ "table" => { ":foo" => "bar" } })
         end
       end
     end
@@ -476,36 +476,36 @@ describe YAML do
     if SafeYAML::YAML_ENGINE == "psych" && RUBY_VERSION >= "1.9.3"
       it "allows exploits through objects defined in YAML w/ !ruby/hash via custom :[]= methods" do
         backdoor = YAML.unsafe_load_file "spec/exploit.1.9.3.yaml"
-        backdoor.should be_exploited_through_setter
+        expect(backdoor).to be_exploited_through_setter
       end
     end
 
     if SafeYAML::YAML_ENGINE == "psych" && RUBY_VERSION >= "1.9.2"
       it "allows exploits through objects defined in YAML w/ !ruby/object via the :init_with method" do
         backdoor = YAML.unsafe_load_file "spec/exploit.1.9.2.yaml"
-        backdoor.should be_exploited_through_init_with
+        expect(backdoor).to be_exploited_through_init_with
       end
     end
 
     it "allows exploits through objects w/ sensitive instance variables defined in YAML w/ !ruby/object" do
       backdoor = YAML.unsafe_load_file "spec/exploit.1.9.2.yaml"
-      backdoor.should be_exploited_through_ivars
+      expect(backdoor).to be_exploited_through_ivars
     end
   end
 
   describe "safe_load_file" do
     it "does NOT allow exploits through objects defined in YAML w/ !ruby/hash" do
       object = YAML.safe_load_file "spec/exploit.1.9.3.yaml"
-      object.should_not be_a(ExploitableBackDoor)
+      expect(object).not_to be_a(ExploitableBackDoor)
     end
 
     it "does NOT allow exploits through objects defined in YAML w/ !ruby/object" do
       object = YAML.safe_load_file "spec/exploit.1.9.2.yaml"
-      object.should_not be_a(ExploitableBackDoor)
+      expect(object).not_to be_a(ExploitableBackDoor)
     end
     
     it "returns false when parsing an empty file" do
-      YAML.safe_load_file("spec/issue49.yml").should == false
+      expect(YAML.safe_load_file("spec/issue49.yml")).to eq(false)
     end
   end
 
@@ -523,13 +523,13 @@ describe YAML do
     context "as long as a :default_mode has been specified" do
       it "doesn't issue a warning for safe mode, since an explicit mode has been set" do
         SafeYAML::OPTIONS[:default_mode] = :safe
-        Kernel.should_not_receive(:warn)
+        expect(Kernel).not_to receive(:warn)
         YAML.load(*arguments)
       end
 
       it "doesn't issue a warning for unsafe mode, since an explicit mode has been set" do
         SafeYAML::OPTIONS[:default_mode] = :unsafe
-        Kernel.should_not_receive(:warn)
+        expect(Kernel).not_to receive(:warn)
         YAML.load(*arguments)
       end
     end
@@ -539,12 +539,12 @@ describe YAML do
       let(:options) { { :safe => safe_mode } }
 
       it "doesn't issue a warning" do
-        Kernel.should_not_receive(:warn)
+        expect(Kernel).not_to receive(:warn)
         YAML.load(*arguments)
       end
 
       it "calls #safe_load if the :safe option is set to true" do
-        YAML.should_receive(:safe_load)
+        expect(YAML).to receive(:safe_load)
         YAML.load(*arguments)
       end
 
@@ -552,7 +552,7 @@ describe YAML do
         let(:safe_mode) { false }
 
         it "calls #unsafe_load if the :safe option is set to false" do
-          YAML.should_receive(:unsafe_load)
+          expect(YAML).to receive(:unsafe_load)
           YAML.load(*arguments)
         end
       end
@@ -560,21 +560,21 @@ describe YAML do
 
     it "issues a warning when the :safe option is omitted" do
       silence_warnings do
-        Kernel.should_receive(:warn)
+        expect(Kernel).to receive(:warn)
         YAML.load(*arguments)
       end
     end
 
     it "only issues a warning once (to avoid spamming an app's output)" do
       silence_warnings do
-        Kernel.should_receive(:warn).once
+        expect(Kernel).to receive(:warn).once
         2.times { YAML.load(*arguments) }
       end
     end
 
     it "defaults to safe mode if the :safe option is omitted" do
       silence_warnings do
-        YAML.should_receive(:safe_load)
+        expect(YAML).to receive(:safe_load)
         YAML.load(*arguments)
       end
     end
@@ -586,13 +586,13 @@ describe YAML do
 
       it "defaults to unsafe mode if the :safe option is omitted" do
         silence_warnings do
-          YAML.should_receive(:unsafe_load)
+          expect(YAML).to receive(:unsafe_load)
           YAML.load(*arguments)
         end
       end
 
       it "calls #safe_load if the :safe option is set to true" do
-        YAML.should_receive(:safe_load)
+        expect(YAML).to receive(:safe_load)
         YAML.load(*(arguments + [{ :safe => true }]))
       end
     end
@@ -603,30 +603,30 @@ describe YAML do
 
     it "issues a warning if the :safe option is omitted" do
       silence_warnings do
-        Kernel.should_receive(:warn)
+        expect(Kernel).to receive(:warn)
         YAML.load_file(filename)
       end
     end
 
     it "doesn't issue a warning as long as the :safe option is specified" do
-      Kernel.should_not_receive(:warn)
+      expect(Kernel).not_to receive(:warn)
       YAML.load_file(filename, :safe => true)
     end
 
     it "defaults to safe mode if the :safe option is omitted" do
       silence_warnings do
-        YAML.should_receive(:safe_load_file)
+        expect(YAML).to receive(:safe_load_file)
         YAML.load_file(filename)
       end
     end
 
     it "calls #safe_load_file if the :safe option is set to true" do
-      YAML.should_receive(:safe_load_file)
+      expect(YAML).to receive(:safe_load_file)
       YAML.load_file(filename, :safe => true)
     end
 
     it "calls #unsafe_load_file if the :safe option is set to false" do
-      YAML.should_receive(:unsafe_load_file)
+      expect(YAML).to receive(:unsafe_load_file)
       YAML.load_file(filename, :safe => false)
     end
 
@@ -637,30 +637,30 @@ describe YAML do
 
       it "defaults to unsafe mode if the :safe option is omitted" do
         silence_warnings do
-          YAML.should_receive(:unsafe_load_file)
+          expect(YAML).to receive(:unsafe_load_file)
           YAML.load_file(filename)
         end
       end
 
       it "calls #safe_load if the :safe option is set to true" do
-        YAML.should_receive(:safe_load_file)
+        expect(YAML).to receive(:safe_load_file)
         YAML.load_file(filename, :safe => true)
       end
     end
 
     it "handles files starting with --- (see issue #48)" do
-      YAML.load_file("spec/issue48.txt", :safe => true).should == {
+      expect(YAML.load_file("spec/issue48.txt", :safe => true)).to eq({
         "title" => "Blah",
         "key"   => "value"
-      }
+      })
     end
 
     it "handles content starting with --- (see issue #48)" do
       yaml = File.read("spec/issue48.txt")
-      YAML.load(yaml, :safe => true).should == {
+      expect(YAML.load(yaml, :safe => true)).to eq({
         "title" => "Blah",
         "key"   => "value"
-      }
+      })
     end
   end
 
@@ -668,21 +668,21 @@ describe YAML do
     context "not a class" do
       it "should raise" do
         expect { SafeYAML::whitelist! :foo }.to raise_error(/not a Class/)
-        SafeYAML::OPTIONS[:whitelisted_tags].should be_empty
+        expect(SafeYAML::OPTIONS[:whitelisted_tags]).to be_empty
       end
     end
 
     context "anonymous class" do
       it "should raise" do
         expect { SafeYAML::whitelist! Class.new }.to raise_error(/cannot be anonymous/)
-        SafeYAML::OPTIONS[:whitelisted_tags].should be_empty
+        expect(SafeYAML::OPTIONS[:whitelisted_tags]).to be_empty
       end
     end
 
     context "with a Class as its argument" do
       it "should configure correctly" do
         expect { SafeYAML::whitelist! OpenStruct }.to_not raise_error
-        SafeYAML::OPTIONS[:whitelisted_tags].grep(/OpenStruct\Z/).should_not be_empty
+        expect(SafeYAML::OPTIONS[:whitelisted_tags].grep(/OpenStruct\Z/)).not_to be_empty
       end
 
       it "successfully deserializes the specified class" do
@@ -692,23 +692,23 @@ describe YAML do
         SafeYAML::OPTIONS[:deserialize_symbols] = true
 
         result = safe_load_round_trip(OpenStruct.new(:foo => "bar"))
-        result.should be_a(OpenStruct)
-        result.foo.should == "bar"
+        expect(result).to be_a(OpenStruct)
+        expect(result.foo).to eq("bar")
       end
 
       it "works for ranges" do
         SafeYAML.whitelist!(Range)
-        safe_load_round_trip(1..10).should == (1..10)
+        expect(safe_load_round_trip(1..10)).to eq(1..10)
       end
 
       it "works for regular expressions" do
         SafeYAML.whitelist!(Regexp)
-        safe_load_round_trip(/foo/).should == /foo/
+        expect(safe_load_round_trip(/foo/)).to eq(/foo/)
       end
 
       it "works for multiple classes" do
         SafeYAML.whitelist!(Range, Regexp)
-        safe_load_round_trip([(1..10), /bar/]).should == [(1..10), /bar/]
+        expect(safe_load_round_trip([(1..10), /bar/])).to eq([(1..10), /bar/])
       end
 
       it "works for arbitrary Exception subclasses" do
@@ -723,8 +723,8 @@ describe YAML do
         SafeYAML.whitelist!(CustomException)
 
         ex = safe_load_round_trip(CustomException.new("blah"))
-        ex.should be_a(CustomException)
-        ex.custom_message.should == "blah"
+        expect(ex).to be_a(CustomException)
+        expect(ex.custom_message).to eq("blah")
       end
     end
   end

--- a/spec/transform/base64_spec.rb
+++ b/spec/transform/base64_spec.rb
@@ -5,7 +5,7 @@ describe SafeYAML::Transform do
     value = "c3VyZS4="
     decoded = SafeYAML::Transform.to_proper_type(value, false, "!binary")
 
-    decoded.should == "sure."
-    decoded.encoding.should == value.encoding if decoded.respond_to?(:encoding)
+    expect(decoded).to eq("sure.")
+    expect(decoded.encoding).to eq(value.encoding) if decoded.respond_to?(:encoding)
   end
 end

--- a/spec/transform/to_date_spec.rb
+++ b/spec/transform/to_date_spec.rb
@@ -2,19 +2,19 @@ require "spec_helper"
 
 describe SafeYAML::Transform::ToDate do
   it "returns true when the value matches a valid Date" do
-    subject.transform?("2013-01-01").should == [true, Date.parse("2013-01-01")]
+    expect(subject.transform?("2013-01-01")).to eq([true, Date.parse("2013-01-01")])
   end
 
   it "returns false when the value does not match a valid Date" do
-    subject.transform?("foobar").should be_false
+    expect(subject.transform?("foobar")).to be_falsey
   end
 
   it "returns false when the value does not end with a Date" do
-    subject.transform?("2013-01-01\nNOT A DATE").should be_false
+    expect(subject.transform?("2013-01-01\nNOT A DATE")).to be_falsey
   end
 
   it "returns false when the value does not begin with a Date" do
-    subject.transform?("NOT A DATE\n2013-01-01").should be_false
+    expect(subject.transform?("NOT A DATE\n2013-01-01")).to be_falsey
   end
 
   it "correctly parses the remaining formats of the YAML spec" do
@@ -27,30 +27,30 @@ describe SafeYAML::Transform::ToDate do
 
     equivalent_values.each do |value|
       success, result = subject.transform?(value)
-      success.should be_true
-      result.should == Time.utc(2001, 12, 15, 2, 59, 43, 100000)
+      expect(success).to be_truthy
+      expect(result).to eq(Time.utc(2001, 12, 15, 2, 59, 43, 100000))
     end
   end
 
   it "converts times to the local timezone" do
     success, result = subject.transform?("2012-12-01 10:33:45 +11:00")
-    success.should be_true
-    result.should == Time.utc(2012, 11, 30, 23, 33, 45)
-    result.gmt_offset.should == Time.local(2012, 11, 30).gmt_offset
+    expect(success).to be_truthy
+    expect(result).to eq(Time.utc(2012, 11, 30, 23, 33, 45))
+    expect(result.gmt_offset).to eq(Time.local(2012, 11, 30).gmt_offset)
   end
 
   it "returns strings for invalid dates" do
-    subject.transform?("0000-00-00").should == [true, "0000-00-00"]
-    subject.transform?("2013-13-01").should == [true, "2013-13-01"]
-    subject.transform?("2014-01-32").should == [true, "2014-01-32"]
+    expect(subject.transform?("0000-00-00")).to eq([true, "0000-00-00"])
+    expect(subject.transform?("2013-13-01")).to eq([true, "2013-13-01"])
+    expect(subject.transform?("2014-01-32")).to eq([true, "2014-01-32"])
   end
 
   it "returns strings for invalid date/times" do
-    subject.transform?("0000-00-00 00:00:00 -0000").should == [true, "0000-00-00 00:00:00 -0000"]
-    subject.transform?("2013-13-01 21:59:43 -05:00").should == [true, "2013-13-01 21:59:43 -05:00"]
-    subject.transform?("2013-01-32 21:59:43 -05:00").should == [true, "2013-01-32 21:59:43 -05:00"]
-    subject.transform?("2013-01-30 25:59:43 -05:00").should == [true, "2013-01-30 25:59:43 -05:00"]
-    subject.transform?("2013-01-30 21:69:43 -05:00").should == [true, "2013-01-30 21:69:43 -05:00"]
+    expect(subject.transform?("0000-00-00 00:00:00 -0000")).to eq([true, "0000-00-00 00:00:00 -0000"])
+    expect(subject.transform?("2013-13-01 21:59:43 -05:00")).to eq([true, "2013-13-01 21:59:43 -05:00"])
+    expect(subject.transform?("2013-01-32 21:59:43 -05:00")).to eq([true, "2013-01-32 21:59:43 -05:00"])
+    expect(subject.transform?("2013-01-30 25:59:43 -05:00")).to eq([true, "2013-01-30 25:59:43 -05:00"])
+    expect(subject.transform?("2013-01-30 21:69:43 -05:00")).to eq([true, "2013-01-30 21:69:43 -05:00"])
 
     # Interesting. It seems that in some older Ruby versions, the below actually parses successfully
     # w/ DateTime.parse; but it fails w/ YAML.load. Whom to follow???

--- a/spec/transform/to_float_spec.rb
+++ b/spec/transform/to_float_spec.rb
@@ -2,41 +2,41 @@ require "spec_helper"
 
 describe SafeYAML::Transform::ToFloat do
   it "returns true when the value matches a valid Float" do
-    subject.transform?("20.00").should == [true, 20.0]
+    expect(subject.transform?("20.00")).to eq([true, 20.0])
   end
 
   it "returns false when the value does not match a valid Float" do
-    subject.transform?("foobar").should be_false
+    expect(subject.transform?("foobar")).to be_falsey
   end
 
   it "returns false when the value spans multiple lines" do
-    subject.transform?("20.00\nNOT A FLOAT").should be_false
+    expect(subject.transform?("20.00\nNOT A FLOAT")).to be_falsey
   end
 
   it "correctly parses all formats in the YAML spec" do
     # canonical
-    subject.transform?("6.8523015e+5").should == [true, 685230.15]
+    expect(subject.transform?("6.8523015e+5")).to eq([true, 685230.15])
 
     # exponentioal
-    subject.transform?("685.230_15e+03").should == [true, 685230.15]
+    expect(subject.transform?("685.230_15e+03")).to eq([true, 685230.15])
 
     # fixed
-    subject.transform?("685_230.15").should == [true, 685230.15]
+    expect(subject.transform?("685_230.15")).to eq([true, 685230.15])
 
     # sexagesimal
-    subject.transform?("190:20:30.15").should == [true, 685230.15]
+    expect(subject.transform?("190:20:30.15")).to eq([true, 685230.15])
 
     # infinity
-    subject.transform?("-.inf").should == [true, (-1.0 / 0.0)]
+    expect(subject.transform?("-.inf")).to eq([true, (-1.0 / 0.0)])
 
     # not a number
     # NOTE: can't use == here since NaN != NaN
     success, result = subject.transform?(".NaN")
-    success.should be_true; result.should be_nan
+    expect(success).to be_truthy; expect(result).to be_nan
   end
 
   # issue 29
   it "returns false for the string '.'" do
-    subject.transform?(".").should be_false
+    expect(subject.transform?(".")).to be_falsey
   end
 end

--- a/spec/transform/to_integer_spec.rb
+++ b/spec/transform/to_integer_spec.rb
@@ -2,63 +2,63 @@ require "spec_helper"
 
 describe SafeYAML::Transform::ToInteger do
   it "returns true when the value matches a valid Integer" do
-    subject.transform?("10").should == [true, 10]
+    expect(subject.transform?("10")).to eq([true, 10])
   end
 
   it "returns false when the value does not match a valid Integer" do
-    subject.transform?("foobar").should be_false
+    expect(subject.transform?("foobar")).to be_falsey
   end
 
   it "returns false when the value spans multiple lines" do
-    subject.transform?("10\nNOT AN INTEGER").should be_false
+    expect(subject.transform?("10\nNOT AN INTEGER")).to be_falsey
   end
 
   it "allows commas in the number" do
-    subject.transform?("1,000").should == [true, 1000]
+    expect(subject.transform?("1,000")).to eq([true, 1000])
   end
 
   it "correctly parses numbers in octal format" do
-    subject.transform?("010").should == [true, 8]
+    expect(subject.transform?("010")).to eq([true, 8])
   end
 
   it "correctly parses numbers in hexadecimal format" do
-    subject.transform?("0x1FF").should == [true, 511]
+    expect(subject.transform?("0x1FF")).to eq([true, 511])
   end
 
   it "defaults to a string for a number that resembles octal format but is not" do
-    subject.transform?("09").should be_false
+    expect(subject.transform?("09")).to be_falsey
   end
 
   it "correctly parses 0 in decimal" do
-    subject.transform?("0").should == [true, 0]
+    expect(subject.transform?("0")).to eq([true, 0])
   end
 
   it "defaults to a string for a number that resembles hexadecimal format but is not" do
-    subject.transform?("0x1G").should be_false
+    expect(subject.transform?("0x1G")).to be_falsey
   end
 
   it "correctly parses all formats in the YAML spec" do
     # canonical
-    subject.transform?("685230").should == [true, 685230]
+    expect(subject.transform?("685230")).to eq([true, 685230])
 
     # decimal
-    subject.transform?("+685_230").should == [true, 685230]
+    expect(subject.transform?("+685_230")).to eq([true, 685230])
 
     # octal
-    subject.transform?("02472256").should == [true, 685230]
+    expect(subject.transform?("02472256")).to eq([true, 685230])
 
     # hexadecimal:
-    subject.transform?("0x_0A_74_AE").should == [true, 685230]
+    expect(subject.transform?("0x_0A_74_AE")).to eq([true, 685230])
 
     # binary
-    subject.transform?("0b1010_0111_0100_1010_1110").should == [true, 685230]
+    expect(subject.transform?("0b1010_0111_0100_1010_1110")).to eq([true, 685230])
 
     # sexagesimal
-    subject.transform?("190:20:30").should == [true, 685230]
+    expect(subject.transform?("190:20:30")).to eq([true, 685230])
   end
 
   # see https://github.com/dtao/safe_yaml/pull/51
   it "strips out underscores before parsing decimal values" do
-    subject.transform?("_850_").should == [true, 850]
+    expect(subject.transform?("_850_")).to eq([true, 850])
   end
 end

--- a/spec/transform/to_symbol_spec.rb
+++ b/spec/transform/to_symbol_spec.rb
@@ -20,32 +20,32 @@ describe SafeYAML::Transform::ToSymbol do
   end
 
   it "returns true when the value matches a valid Symbol" do
-    with_symbol_deserialization { subject.transform?(":foo")[0].should be_true }
+    with_symbol_deserialization { expect(subject.transform?(":foo")[0]).to be_truthy }
   end
 
   it "returns true when the value matches a valid String+Symbol" do
-    with_symbol_deserialization { subject.transform?(':"foo"')[0].should be_true }
+    with_symbol_deserialization { expect(subject.transform?(':"foo"')[0]).to be_truthy }
   end
 
   it "returns true when the value matches a valid String+Symbol with 's" do
-    with_symbol_deserialization { subject.transform?(":'foo'")[0].should be_true }
+    with_symbol_deserialization { expect(subject.transform?(":'foo'")[0]).to be_truthy }
   end
 
   it "returns true when the value has special characters and is wrapped in a String" do
-    with_symbol_deserialization { subject.transform?(':"foo.bar"')[0].should be_true }
+    with_symbol_deserialization { expect(subject.transform?(':"foo.bar"')[0]).to be_truthy }
   end
 
   it "returns false when symbol deserialization is disabled" do
-    without_symbol_deserialization { subject.transform?(":foo").should be_false }
+    without_symbol_deserialization { expect(subject.transform?(":foo")).to be_falsey }
   end
 
   it "returns false when the value does not match a valid Symbol" do
-    with_symbol_deserialization { subject.transform?("foo").should be_false }
+    with_symbol_deserialization { expect(subject.transform?("foo")).to be_falsey }
   end
 
   it "returns false when the symbol does not begin the line" do
     with_symbol_deserialization do
-      subject.transform?("NOT A SYMBOL\n:foo").should be_false
+      expect(subject.transform?("NOT A SYMBOL\n:foo")).to be_falsey
     end
   end
 end

--- a/spec/yaml_spec.rb
+++ b/spec/yaml_spec.rb
@@ -5,11 +5,11 @@ require "spec_helper"
 describe YAML do
   context "when you've only required safe_yaml/load", :libraries => true do
     it "YAML.load doesn't get monkey patched" do
-      YAML.method(:load).should == ORIGINAL_YAML_LOAD
+      expect(YAML.method(:load)).to eq(ORIGINAL_YAML_LOAD)
     end
 
     it "YAML.load_file doesn't get monkey patched" do
-      YAML.method(:load_file).should == ORIGINAL_YAML_LOAD_FILE
+      expect(YAML.method(:load_file)).to eq(ORIGINAL_YAML_LOAD_FILE)
     end
   end
 end


### PR DESCRIPTION
This conversion is done by Transpec 2.3.6 with the following command:
    transpec -f
- 130 conversions
  from: obj.should
    to: expect(obj).to
- 90 conversions
  from: == expected
    to: eq(expected)
- 16 conversions
  from: obj.should_receive(:message)
    to: expect(obj).to receive(:message)
- 13 conversions
  from: be_false
    to: be_falsey
- 7 conversions
  from: be_true
    to: be_truthy
- 7 conversions
  from: obj.should_not
    to: expect(obj).not_to
- 4 conversions
  from: obj.should_not_receive(:message)
    to: expect(obj).not_to receive(:message)
- 2 conversions
  from: lambda { }.should
    to: expect { }.to
- 1 conversion
  from: =~ [1, 2]
    to: match_array([1, 2])
- 1 conversion
  from: obj.stub(:message)
    to: allow(obj).to receive(:message)

For more details: https://github.com/yujinakayama/transpec#supported-conversions
