### PR TITLE
Fix ruby warning about shadowed variable

### DIFF
--- a/lib/safe_yaml/resolver.rb
+++ b/lib/safe_yaml/resolver.rb
@@ -52,7 +52,7 @@ module SafeYAML
       tag = get_and_check_node_tag(node)
       arr = @initializers.include?(tag) ? @initializers[tag].call : []
 
-      seq.inject(arr) { |array, node| array << resolve_node(node) }
+      seq.inject(arr) { |array, n| array << resolve_node(n) }
     end
 
     def resolve_scalar(node)


### PR DESCRIPTION
> gems/ruby-2.1.2/gems/safe_yaml-1.0.3/lib/safe_yaml/resolver.rb:55: warning: shadowing outer local variable - node

When you ruby with `-w` it complains about shadowed variable when using safe_yaml gem.
