### PR TITLE
Add missing require for Psych::Nodes

### DIFF
--- a/lib/safe_yaml/psych_resolver.rb
+++ b/lib/safe_yaml/psych_resolver.rb
@@ -1,3 +1,5 @@
+require "psych/nodes"
+
 module SafeYAML
   class PsychResolver < Resolver
     NODE_TYPES = {


### PR DESCRIPTION
This resolves an issue where you would get uninitialized constant Psych::Nodes (NameError) when running with newer version of Psych.

Fixes #72