### PR TITLE
Update CHANGES.md for version 1.0.3 & 1.0.4

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,16 @@
+1.0.4
+-----
+
+- added support for Ruby 2.2
+- converted specs to RSpec 3.0.2 syntax
+
+1.0.3
+-----
+
+- introduced bin/safe_yaml
+- stopped running libyaml check on load
+- corrected libyaml check implementation
+
 1.0.2
 -----
 


### PR DESCRIPTION
I needed to update safe_yaml for Ruby 2.2.0 and wanted to understand the changes
between 1.0.2 and 1.0.4. Figured I'd attempt to updated CHANGES.md in the process.
