### PR TITLE
fix transformation of integers with leading underscores

### DIFF
--- a/lib/safe_yaml/transform/to_integer.rb
+++ b/lib/safe_yaml/transform/to_integer.rb
@@ -10,8 +10,10 @@ module SafeYAML
 
       def transform?(value)
         MATCHERS.each_with_index do |matcher, idx|
-          value = value.gsub(/[_,]/, "") if idx == 0
-          return true, Integer(value) if matcher.match(value)
+          if matcher.match(value)
+            value = value.gsub(/[_,]/, "") if idx == 0
+            return true, Integer(value)
+          end
         end
         try_edge_cases?(value)
       end

--- a/spec/transform/to_integer_spec.rb
+++ b/spec/transform/to_integer_spec.rb
@@ -59,6 +59,10 @@ describe SafeYAML::Transform::ToInteger do
 
   # see https://github.com/dtao/safe_yaml/pull/51
   it "strips out underscores before parsing decimal values" do
-    expect(subject.transform?("_850_")).to eq([true, 850])
+    expect(subject.transform?("850_")).to eq([true, 850])
+  end
+
+  it "does not parse decimal values with leading underscores" do
+    expect(subject.transform?("_850")).to be_falsey
   end
 end


### PR DESCRIPTION
I believe these should come over as strings. Otherwise `YAML.load(YAML.dump("_1"))` returns `1` with Psych