### PR TITLE
Allows custom transformers

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ The most important option is the `:safe` option (default: `true`), which control
 
 - `:raise_on_unknown_tag` (default: `false`): Represents the highest possible level of paranoia. If the YAML engine encounters any tag other than ones that are automatically trusted by SafeYAML or that you've explicitly whitelisted, it will raise an exception. This may be a good choice if you expect to always be dealing with perfectly safe YAML and want your application to fail loudly upon encountering questionable data.
 
+- `:transformers` (default: `nil`): Allows you to provide `Transformer`s to customize the parsing process. It can be used to ignore some data types or to parse something in a different way.
+
 All of the above options can be set at the global level via `SafeYAML::OPTIONS`. You can also set each one individually per call to `YAML.load`; an option explicitly passed to `load` will take precedence over an option specified globally.
 
 What if I don't *want* to patch `YAML`?
@@ -151,9 +153,9 @@ And in case you were wondering: no, this feature will *not* allow would-be attac
 
 ```ruby
 yaml = <<-EOYAML
---- !ruby/object:OpenStruct 
-table: 
-  :backdoor: !ruby/hash:ClassBuilder 
+--- !ruby/object:OpenStruct
+table:
+  :backdoor: !ruby/hash:ClassBuilder
     "foo; end; puts %(I'm in yr system!); def bar": "baz"
 EOYAML
 ```

--- a/lib/safe_yaml/load.rb
+++ b/lib/safe_yaml/load.rb
@@ -32,7 +32,8 @@ module SafeYAML
     :deserialize_symbols  => false,
     :whitelisted_tags     => [],
     :custom_initializers  => {},
-    :raise_on_unknown_tag => false
+    :raise_on_unknown_tag => false,
+    :transformers         => nil
   })
 
   OPTIONS = Deep.copy(DEFAULT_OPTIONS)

--- a/lib/safe_yaml/transform.rb
+++ b/lib/safe_yaml/transform.rb
@@ -2,7 +2,7 @@ require 'base64'
 
 module SafeYAML
   class Transform
-    TRANSFORMERS = [
+    DEFAULT_TRANSFORMERS = [
       Transform::ToSymbol.new,
       Transform::ToInteger.new,
       Transform::ToFloat.new,
@@ -15,7 +15,8 @@ module SafeYAML
       return value if quoted
 
       if value.is_a?(String)
-        TRANSFORMERS.each do |transformer|
+        transformers = options[:transformers] || DEFAULT_TRANSFORMERS
+        transformers.each do |transformer|
           success, transformed_value = transformer.method(:transform?).arity == 1 ?
             transformer.transform?(value) :
             transformer.transform?(value, options)


### PR DESCRIPTION
Allows people to provide `Transformer`s to customize the parsing process. It can be used to ignore some data types or to parse something in a different way.

The CI process at GitLab can be configured using YAML, but it is important for them to keep the original value of bool data, so people are using `"true"` to make it happen and not `true`, as discussed [here](https://gitlab.com/gitlab-org/gitlab-ce/issues/36401).