### PR TITLE
Fix psych load deprecation notice

### DIFF
--- a/lib/safe_yaml.rb
+++ b/lib/safe_yaml.rb
@@ -7,11 +7,11 @@ module YAML
     arguments = [yaml]
 
     if safe_mode == :safe
-      arguments << filename if SafeYAML::YAML_ENGINE == "psych"
+      arguments << { filename: filename } if SafeYAML::YAML_ENGINE == "psych"
       arguments << options_for_safe_load(options)
       safe_load(*arguments)
     else
-      arguments << filename if SafeYAML::MULTI_ARGUMENT_YAML_LOAD
+      arguments << { filename: filename } if SafeYAML::MULTI_ARGUMENT_YAML_LOAD
       unsafe_load(*arguments)
     end
   end
@@ -36,7 +36,7 @@ module YAML
   if SafeYAML::MULTI_ARGUMENT_YAML_LOAD
     def self.unsafe_load_file(filename)
       # https://github.com/tenderlove/psych/blob/v1.3.2/lib/psych.rb#L296-298
-      File.open(filename, 'r:bom|utf-8') { |f| self.unsafe_load(f, filename) }
+      File.open(filename, 'r:bom|utf-8') { |f| self.unsafe_load(f, filename: filename) }
     end
 
   else

--- a/lib/safe_yaml/load.rb
+++ b/lib/safe_yaml/load.rb
@@ -146,7 +146,7 @@ module SafeYAML
       else
         safe_resolver = SafeYAML::PsychResolver.new(options)
         tree = SafeYAML::MULTI_ARGUMENT_YAML_LOAD ?
-          Psych.parse(yaml, filename) :
+          Psych.parse(yaml, filename: filename) :
           Psych.parse(yaml)
         return safe_resolver.resolve_node(tree)
       end


### PR DESCRIPTION
I've been getting this deprecation notice on my tests and they're logged in the safe_yaml test suite as well:

```
......../Users/Ayush/Developer/Personal/open_source/safe_yaml/lib/safe_yaml.rb:39: Passing filename with the 2nd argument of Psych.load is deprecated. Use keyword argument like Psych.load(yaml, filename: ...) instead.
```

I've fixed this by adding the filename keyword argument.