### PR TITLE
add base64 as dependency

### DIFF
--- a/safe_yaml.gemspec
+++ b/safe_yaml.gemspec
@@ -16,4 +16,6 @@ Gem::Specification.new do |gem|
   gem.executables   = ["safe_yaml"]
 
   gem.required_ruby_version = ">= 1.8.7"
+
+  gem.add_dependency("base64", ">= 0.1.0")
 end


### PR DESCRIPTION
As of ruby 3.3.0 I started getting the warning:

`/Users/username/.gem/ruby/3.3.0/gems/safe_yaml-1.0.5/lib/safe_yaml/transform.rb:1: warning: base64 was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add base64 to your Gemfile or gemspec. Also contact author of safe_yaml-1.0.5 to add base64 into its gemspec.`

So I added it to the gemspec. There aren't many versions of the gem but looking at the [release notes for base64](https://github.com/ruby/base64/releases) I _think_ it is fine to have really any version of it, so I made the version requirement anything from 0.1.0 or greater

Notably if we wanted, this could be a conditional dependency on the ruby version wrapped with something like:
```Ruby
if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.3')
  s.add_dependency("base64", ">= 0.1.0")
end
```