### PR TITLE
add base64 dependancy when using ruby 3.3 or greater

### DIFF
--- a/safe_yaml.gemspec
+++ b/safe_yaml.gemspec
@@ -16,4 +16,8 @@ Gem::Specification.new do |gem|
   gem.executables   = ["safe_yaml"]
 
   gem.required_ruby_version = ">= 1.8.7"
+
+  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.3')
+    s.add_dependency("base64", ">= 0.1.0")
+  end
 end


### PR DESCRIPTION
This is a reopening of the PR that I accidentally closed here https://github.com/dtao/safe_yaml/pull/107

I now have it as a conditional based on the ruby version so that we only inject the dependency manually when on the ruby versions that require it.