### PR TITLE
add dependency to base64 as removed from ruby 3.4 stdlib

### DIFF
--- a/safe_yaml.gemspec
+++ b/safe_yaml.gemspec
@@ -16,4 +16,6 @@ Gem::Specification.new do |gem|
   gem.executables   = ["safe_yaml"]
 
   gem.required_ruby_version = ">= 1.8.7"
+
+  gem.add_dependency("base64")
 end


### PR DESCRIPTION
`safe_yaml` fails upon being required in Ruby 3.4 because `base64` has been removed from stdlib.

```
0.810 /usr/local/bundle/gems/safe_yaml-1.0.5/lib/safe_yaml/transform.rb:1:in 'Kernel#require': cannot load such file -- base64 (LoadError)                                                                         
0.810   from /usr/local/bundle/gems/safe_yaml-1.0.5/lib/safe_yaml/transform.rb:1:in '<top (required)>'
0.810   from /usr/local/bundle/gems/safe_yaml-1.0.5/lib/safe_yaml/load.rb:22:in 'Kernel#require'
0.810   from /usr/local/bundle/gems/safe_yaml-1.0.5/lib/safe_yaml/load.rb:22:in '<top (required)>'
```